### PR TITLE
Add lint step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,5 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm install
+      - run: npm run lint
       - run: npm test


### PR DESCRIPTION
## Summary
- run `npm run lint` as part of CI

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_b_685213c5ac448324854068224172825e