### PR TITLE
Fix audio transcription temporary file handling

### DIFF
--- a/functions/communication/audioToTextFile.ts
+++ b/functions/communication/audioToTextFile.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 import https from 'https';
 import OpenAI from 'openai';
 
@@ -12,7 +13,8 @@ export const audioFileToText = async (request: any): Promise<{ success: boolean;
 		return { success: false, error: 'Missing required parameter: fileUrl' };
 	}
 
-	const filePath = path.join('temp_audio_file.mp3');
+        const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'audio-'));
+        const filePath = path.join(tempDir, 'audio.mp3');
 
 	try {
 		// Step 1: Download the audio file from the URL
@@ -33,10 +35,10 @@ export const audioFileToText = async (request: any): Promise<{ success: boolean;
 
 		// Step 3: Return the transcription result
 		return { success: true, data: transcription.text };
-	} catch (error: any) {
-		return { success: false, error: error.message };
-	} finally {
-		// Clean up the temporary file
-		fs.unlinkSync(filePath);
-	}
+        } catch (error: any) {
+                return { success: false, error: error.message };
+        } finally {
+                // Clean up the temporary file
+                await fs.promises.unlink(filePath).catch(() => undefined);
+        }
 };


### PR DESCRIPTION
## Summary
- create a unique temp directory before downloading audio
- remove audio file asynchronously with `fs.promises.unlink`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685213f64c4c83249c8264415ee9a0a6