### PR TITLE
Add TOKEN_SERVICE_URL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ GDRIVE_SERVICE_ACCOUNT_JSON={"client_email":"example@project.iam.gserviceaccount
 # Trusted API key
 TRUSTED_API_KEY=api-key
 JWT_SECRET=your-jwt-secret
+TOKEN_SERVICE_URL=https://jwt.aquataze.com/
 
 # Cloudinary
 CLOUDINARY_CLOUD_NAME=main-cloud

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Create a `.env` file using `.env.example` as a reference. Required variables inc
 - `GDRIVE_SERVICE_ACCOUNT_JSON` – Google Drive service account JSON
 - `TRUSTED_API_KEY` – Shared API key for protected routes
 - `JWT_SECRET` – Secret used for JWT verification
+- `TOKEN_SERVICE_URL` – URL of the JWT token service
 - Cloudinary credentials: `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`
 - Azure speech: `AZURE_SPEECH_KEY`, `AZURE_SPEECH_REGION`
 - WhatsApp integration: `WHATSAPP_GRAPH_API_TOKEN`, `WHATSAPP_GRAPH_API_URL`, `WHATSAPP_ASSISTANT_PHONE_NUMBER`

--- a/utils/getToken.ts
+++ b/utils/getToken.ts
@@ -5,7 +5,7 @@ import FormData from 'form-data';
 import { Collection } from 'mongodb';
 import { connectToMongo } from './mongo';
 
-const tokenUrl = 'https://jwt.aquataze.com/';
+const tokenUrl = process.env.TOKEN_SERVICE_URL || '';
 const apiKey = process.env.TRUSTED_API_KEY || '';
 const tokenFilePath = path.resolve(__dirname, 'token.json');
 

--- a/utils/validateEnv.ts
+++ b/utils/validateEnv.ts
@@ -16,8 +16,9 @@ export function validateEnv(): void {
 			}
 		},
 		TRUSTED_API_KEY: /.+/,
-		JWT_SECRET: /.+/,
-		CLOUDINARY_CLOUD_NAME: /.+/,
+                JWT_SECRET: /.+/,
+                TOKEN_SERVICE_URL: /^https?:\/\/.+/,
+                CLOUDINARY_CLOUD_NAME: /.+/,
 		CLOUDINARY_API_KEY: /.+/,
 		CLOUDINARY_API_SECRET: /.+/,
 		AZURE_SPEECH_KEY: /.+/,


### PR DESCRIPTION
## Summary
- add `TOKEN_SERVICE_URL` to README and `.env.example`
- load token service URL from environment
- validate new variable in env checker

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6852214fbd9c83249059b18f2551a06b