### PR TITLE
Add robust env validation

### DIFF
--- a/api/getCurrentDateTime.ts
+++ b/api/getCurrentDateTime.ts
@@ -2,6 +2,10 @@ import { find } from 'geo-tz';
 import { VercelRequest } from '@vercel/node';
 import { getLocationData } from '../functions/resolvers/location';
 import { getStateAbbreviation } from '../utils/getStateAbbreviation';
+import { ensureEnv } from '../utils/validateEnv';
+
+// Validate all required environment variables once on load
+ensureEnv();
 
 export const getCurrentDateTime = async (request: VercelRequest) => {
 	let { city, state, zipCode, country, lat, lon } = request.body;

--- a/api/toolsHandler.ts
+++ b/api/toolsHandler.ts
@@ -1,7 +1,7 @@
 // Communication functions
 import { handleToolOptions } from '../functions/handleToolOptions';
 import { verifyRequestToken } from '../utils/verifyJWT';
-import { validateEnv } from '../utils/validateEnv';
+import { ensureEnv } from '../utils/validateEnv';
 import { toolsMap } from './toolsMap';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
@@ -11,7 +11,7 @@ interface AIRequest {
 }
 
 // Ensure all required environment variables are set when the module loads
-validateEnv();
+ensureEnv();
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
 	if (request.method === 'OPTIONS') {

--- a/api/welcome.ts
+++ b/api/welcome.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { verifyRequestToken } from '../utils/verifyJWT';
-import { validateEnv } from '../utils/validateEnv';
+import { ensureEnv } from '../utils/validateEnv';
 
 // Validate environment on module load
-validateEnv();
+ensureEnv();
 
 const handler = async (request: VercelRequest, response: VercelResponse) => {
 	const verification = verifyRequestToken(request);

--- a/functions/communication/downloadWhatsAppMedia.ts
+++ b/functions/communication/downloadWhatsAppMedia.ts
@@ -3,6 +3,10 @@ import axios from 'axios';
 import OpenAI from 'openai';
 import { cloudinaryConfig } from '../../utils/cloudinaryConfig';
 import { updateCloudinaryMetadata } from '../../utils/updateCloudinaryMetadata';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Ensure env vars for external services are set
+ensureEnv();
 
 const openai = new OpenAI();
 

--- a/functions/communication/listenToWhatsAppVoiceAudio.ts
+++ b/functions/communication/listenToWhatsAppVoiceAudio.ts
@@ -6,6 +6,10 @@ import stream from 'stream';
 import OpenAI from 'openai';
 import { promisify } from 'util';
 import { cloudinaryConfig as cloudinary } from '../../utils/cloudinaryConfig';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables for OpenAI and WhatsApp API
+ensureEnv();
 
 const openai = new OpenAI();
 const pipeline = promisify(stream.pipeline);

--- a/functions/communication/markWhatsAppMessageRead.ts
+++ b/functions/communication/markWhatsAppMessageRead.ts
@@ -1,4 +1,8 @@
 import axios from 'axios';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables for WhatsApp API
+ensureEnv();
 
 interface MarkWhatsAppMessageReadRequestParams {
 	body: {

--- a/functions/communication/requestWhatsAppLocation.ts
+++ b/functions/communication/requestWhatsAppLocation.ts
@@ -1,4 +1,8 @@
 import axios from 'axios';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate WhatsApp environment variables on import
+ensureEnv();
 
 interface RequestWhatsAppLocationParams {
 	body: {

--- a/functions/communication/sendEmail.ts
+++ b/functions/communication/sendEmail.ts
@@ -1,10 +1,10 @@
 import { GmailMailer } from 'gmail-node-mailer';
-import { validateEnv } from '../../utils/validateEnv';
+import { ensureEnv } from '../../utils/validateEnv';
 import { encodeEmailContent, EncodingType } from '../../utils/encodeEmailContent';
 import { SendEmailMessageRequestParams, SendMessageResponse } from './types';
 
 // Ensure required environment variables are set when the module is imported
-validateEnv();
+ensureEnv();
 
 export const sendEmail = async (request: SendEmailMessageRequestParams): Promise<SendMessageResponse> => {
 	const { to, body, from, subject } = request.body;

--- a/functions/communication/sendTextMessage.ts
+++ b/functions/communication/sendTextMessage.ts
@@ -1,9 +1,9 @@
 import twilio from 'twilio';
-import { validateEnv } from '../../utils/validateEnv';
+import { ensureEnv } from '../../utils/validateEnv';
 import { SendTextMessageRequestParams, SendMessageResponse } from './types';
 
 // Validate required environment variables on import
-validateEnv();
+ensureEnv();
 
 export const sendTextMessage = async (request: SendTextMessageRequestParams): Promise<SendMessageResponse> => {
 	const { TWILIO_ASSISTANT_PHONE_NUMBER, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } = process.env;

--- a/functions/communication/sendWhatsAppLocation.ts
+++ b/functions/communication/sendWhatsAppLocation.ts
@@ -1,4 +1,8 @@
 import axios from 'axios';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables when module is loaded
+ensureEnv();
 
 interface SendWhatsAppLocationRequestParams {
 	body: {

--- a/functions/communication/sendWhatsAppMessage.ts
+++ b/functions/communication/sendWhatsAppMessage.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import { validateEnv } from '../../utils/validateEnv';
+import { ensureEnv } from '../../utils/validateEnv';
 import { SendWhatsAppMessageRequestParams, SendMessageResponse } from './types';
 
 // Check environment when module loads
-validateEnv();
+ensureEnv();
 
 export const sendWhatsAppMessage = async (request: SendWhatsAppMessageRequestParams): Promise<SendMessageResponse> => {
 	const { WHATSAPP_GRAPH_API_TOKEN, WHATSAPP_GRAPH_API_URL, WHATSAPP_ASSISTANT_PHONE_NUMBER, WHATSAPP_PHONE_ID } = process.env;

--- a/functions/communication/sendWhatsAppVoiceMessage.ts
+++ b/functions/communication/sendWhatsAppVoiceMessage.ts
@@ -4,6 +4,10 @@ import path from 'path';
 import OpenAI from 'openai';
 import { cloudinaryConfig } from '../../utils/cloudinaryConfig';
 import { SendWhatsAppMessageRequestParams, SendMessageResponse } from './types';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables for OpenAI and WhatsApp API
+ensureEnv();
 
 const openai = new OpenAI();
 

--- a/functions/communication/sendWhatsDocument.ts
+++ b/functions/communication/sendWhatsDocument.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 import path from 'path';
 import { SendMessageResponse, SendWhatsAppDocumentRequestParams } from './types';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables on import
+ensureEnv();
 
 export const sendWhatsFile = async (request: SendWhatsAppDocumentRequestParams): Promise<SendMessageResponse> => {
 	const { WHATSAPP_GRAPH_API_TOKEN, WHATSAPP_GRAPH_API_URL, WHATSAPP_ASSISTANT_PHONE_NUMBER, WHATSAPP_PHONE_ID } = process.env;

--- a/functions/communication/viewAndDescribeWhatsAppImage.ts
+++ b/functions/communication/viewAndDescribeWhatsAppImage.ts
@@ -3,6 +3,10 @@ import stream from 'stream';
 import OpenAI from 'openai';
 import { promisify } from 'util';
 import { cloudinaryConfig as cloudinary } from '../../utils/cloudinaryConfig';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate env vars for OpenAI and Cloudinary
+ensureEnv();
 
 const openai = new OpenAI();
 const pipeline = promisify(stream.pipeline);

--- a/functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc.ts
+++ b/functions/googleBusinessStuff/createGoogleSheetOrGoogleDoc.ts
@@ -1,5 +1,9 @@
 import { google } from 'googleapis';
 import { VercelRequest } from '@vercel/node';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate Google Drive service account configuration
+ensureEnv();
 
 function getServiceAccount() {
 	const json = process.env.GDRIVE_SERVICE_ACCOUNT_JSON;

--- a/functions/resolvers/googleAddressResolver.ts
+++ b/functions/resolvers/googleAddressResolver.ts
@@ -1,5 +1,9 @@
 import NodeGeocoder from 'node-geocoder';
 import { VercelRequest } from '@vercel/node';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables when this module is loaded
+ensureEnv();
 
 const geocoder = NodeGeocoder({
 	provider: 'google',

--- a/functions/resolvers/resolveLocation.ts
+++ b/functions/resolvers/resolveLocation.ts
@@ -3,6 +3,10 @@ import gps2zip from 'gps2zip';
 import { connectToMongo } from '../../utils/mongo';
 import { LocationInput, LocationOutput } from '../../types/location';
 import { getStateAbbreviation } from '../../utils/getStateAbbreviation';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Run environment validation once when module is imported
+ensureEnv();
 
 const fetchCoordinates = async (url: string) => {
 	try {

--- a/functions/searchGoogle/googleImageSearch.ts
+++ b/functions/searchGoogle/googleImageSearch.ts
@@ -2,6 +2,10 @@ import axios from 'axios';
 import { VercelRequest } from '@vercel/node';
 import { parseQueryParams } from '../../utils/parseQueryParams';
 import { ImageResult, ImageSearchOptions, ImageSearchResponse } from './searchGoogleTypes';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate API keys used for image search
+ensureEnv();
 
 const fetchImages = async (options: ImageSearchOptions, apiKey: string): Promise<ImageResult[]> => {
 	const params: Record<string, string> = {

--- a/functions/searchGoogle/googleWebSearch.ts
+++ b/functions/searchGoogle/googleWebSearch.ts
@@ -2,6 +2,10 @@ import axios from 'axios';
 import { parseQueryParams } from '../../utils/parseQueryParams';
 import { SerpSearchRequest, WebSearchResponse, WebSearchResult } from './searchGoogleTypes';
 import { VercelRequest } from '@vercel/node';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables for Scale SERP
+ensureEnv();
 
 export const searchGoogle = async (request: VercelRequest): Promise<WebSearchResponse> => {
 	try {

--- a/functions/weather/openWeatherFunction.ts
+++ b/functions/weather/openWeatherFunction.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 import { LocationOutput } from '../../types/location';
 import { resolveLocation } from '../resolvers/resolveLocation';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables when the module loads
+ensureEnv();
 
 const fetchWeatherData = async ({ lat, lon, zipCode }: { lat?: number; lon?: number; zipCode?: string }) => {
 	const weatherApiKey = process.env.OPEN_WEATHER_API_KEY;

--- a/functions/weather/todaysWeather.ts
+++ b/functions/weather/todaysWeather.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 import { VercelRequest } from '@vercel/node';
 import { WeatherRequest, TodaysWeatherResponse } from './weatherTypes';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate environment variables on import
+ensureEnv();
 
 export const fetchTodaysWeatherData = async (request: VercelRequest): Promise<TodaysWeatherResponse> => {
 	const weatherApiKey = process.env.VISUAL_CROSSING_WEATHER_API_KEY;

--- a/functions/weather/uploaders/uploadToCloudinary.ts
+++ b/functions/weather/uploaders/uploadToCloudinary.ts
@@ -1,6 +1,10 @@
 import { Readable } from 'stream';
 import { VercelRequest } from '@vercel/node';
 import { v2 as cloudinary } from 'cloudinary';
+import { ensureEnv } from '../../../utils/validateEnv';
+
+// Validate env vars for Cloudinary config
+ensureEnv();
 
 cloudinary.config({
 	cloud_name: process.env.CLOUDINARY_CLOUD_NAME,

--- a/functions/weather/visualWeatherFunction.ts
+++ b/functions/weather/visualWeatherFunction.ts
@@ -1,5 +1,9 @@
 import axios from 'axios';
 import { VercelRequest } from '@vercel/node';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Ensure required environment variables are present
+ensureEnv();
 
 const fetchWeatherData = async ({ city, state, country, zipCode, lat, lon }: any) => {
 	const weatherApiKey = process.env.VISUAL_CROSSING_WEATHER_API_KEY;

--- a/functions/webTools/generateLandingPage.ts
+++ b/functions/webTools/generateLandingPage.ts
@@ -2,6 +2,10 @@ import axios from 'axios';
 import { load } from 'cheerio';
 import { VercelRequest } from '@vercel/node';
 import { parseQueryParams } from '../../utils/parseQueryParams';
+import { ensureEnv } from '../../utils/validateEnv';
+
+// Validate OpenAI API configuration
+ensureEnv();
 
 const openaiApiKey = process.env.OPENAI_API_KEY;
 

--- a/utils/azureSpeechConfig.ts
+++ b/utils/azureSpeechConfig.ts
@@ -1,4 +1,8 @@
 import { SpeechConfig } from 'microsoft-cognitiveservices-speech-sdk';
+import { ensureEnv } from './validateEnv';
+
+// Validate environment variables for Azure speech
+ensureEnv();
 
 export const AZURE_SPEECH_KEY = process.env.AZURE_SPEECH_KEY;
 export const AZURE_SPEECH_REGION = process.env.AZURE_SPEECH_REGION;

--- a/utils/cloudinaryConfig.ts
+++ b/utils/cloudinaryConfig.ts
@@ -1,4 +1,8 @@
 import { v2 as cloudinary } from 'cloudinary';
+import { ensureEnv } from './validateEnv';
+
+// Validate cloudinary environment variables
+ensureEnv();
 
 const CLOUDINARY_CLOUD_NAME = process.env.CLOUDINARY_CLOUD_NAME;
 const CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY;

--- a/utils/getToken.ts
+++ b/utils/getToken.ts
@@ -4,6 +4,10 @@ import * as path from 'path';
 import FormData from 'form-data';
 import { Collection } from 'mongodb';
 import { connectToMongo } from './mongo';
+import { ensureEnv } from './validateEnv';
+
+// Validate environment variables for token service
+ensureEnv();
 
 const tokenUrl = process.env.TOKEN_SERVICE_URL || '';
 const apiKey = process.env.TRUSTED_API_KEY || '';

--- a/utils/mongo.ts
+++ b/utils/mongo.ts
@@ -1,4 +1,8 @@
 import { MongoClient, Db, Collection } from 'mongodb';
+import { ensureEnv } from './validateEnv';
+
+// Validate MongoDB environment configuration
+ensureEnv();
 
 const { DB_USERNAME: dbUsername = '', DB_PASSWORD: dbPassword = '', DB_NAME: dbName = '', DB_CLUSTER: dbClusterName = '' } = process.env;
 

--- a/utils/updateGoogleDriveFileDescription.ts
+++ b/utils/updateGoogleDriveFileDescription.ts
@@ -1,4 +1,8 @@
 import { google, drive_v3 } from 'googleapis';
+import { ensureEnv } from './validateEnv';
+
+// Validate environment variables for Google Drive access
+ensureEnv();
 
 function getServiceAccount() {
 	const json = process.env.GDRIVE_SERVICE_ACCOUNT_JSON;

--- a/utils/validateEnv.ts
+++ b/utils/validateEnv.ts
@@ -1,3 +1,5 @@
+let validated = false;
+
 export function validateEnv(): void {
 	const rules: Record<string, RegExp | ((v: string) => boolean)> = {
 		OPENAI_API_KEY: /.+/,
@@ -46,4 +48,14 @@ export function validateEnv(): void {
 			throw new Error(`Invalid format for environment variable: ${key}`);
 		}
 	}
+}
+
+export function ensureEnv(): void {
+        if (process.env.NODE_ENV === 'test') {
+                return;
+        }
+        if (!validated) {
+                validateEnv();
+                validated = true;
+        }
 }

--- a/utils/verifyJWT.ts
+++ b/utils/verifyJWT.ts
@@ -1,5 +1,9 @@
 import jwt, { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 import type { VercelRequest } from '@vercel/node';
+import { ensureEnv } from './validateEnv';
+
+// Validate JWT_SECRET and related configuration
+ensureEnv();
 
 export type JWTVerificationResult<T> = { valid: true; payload: T } | { valid: false; error: 'expired' | 'malformed' | 'invalid' };
 


### PR DESCRIPTION
## Summary
- validate env vars through new `ensureEnv` helper
- use `ensureEnv` in all entrypoints and modules requiring env vars
- skip env validation during test runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68526fa3a6dc8324b64de52467996106