### PR TITLE
Convert tests to TypeScript

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(test).ts'],
+  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
 };

--- a/tests/convertLength.test.ts
+++ b/tests/convertLength.test.ts
@@ -1,11 +1,11 @@
-const { convertLength } = require('../functions/unitConversion/convertLength.ts');
+import { convertLength } from '../functions/unitConversion/convertLength';
 
 describe('convertLength', () => {
   test('converts meters to feet', async () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'meters', to: 'feet', value: '1' },
-    });
+    } as any);
     expect(result.status).toBe(true);
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
@@ -20,7 +20,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'POST',
       body: { from: 'feet', to: 'meters', value: 3.28 },
-    });
+    } as any);
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: true,
@@ -34,7 +34,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'inches', to: 'centimeters', value: '1' },
-    });
+    } as any);
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: true,
@@ -48,7 +48,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'centimeters', to: 'inches', value: '2.54' },
-    });
+    } as any);
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: true,
@@ -62,7 +62,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'yards', to: 'meters', value: '1' },
-    });
+    } as any);
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: false,
@@ -76,7 +76,7 @@ describe('convertLength', () => {
     const result = await convertLength({
       method: 'GET',
       query: { from: 'meters', to: 'feet', value: 'abc' },
-    });
+    } as any);
     expect(result.conversions[0]).toEqual(
       expect.objectContaining({
         status: false,
@@ -91,7 +91,7 @@ describe('convertLength', () => {
       to: 'feet',
       value: 1,
     }));
-    const result = await convertLength({ method: 'POST', body: many });
+    const result = await convertLength({ method: 'POST', body: many } as any);
     expect(result).toEqual({
       status: false,
       message:

--- a/tests/encodeEmailContent.test.ts
+++ b/tests/encodeEmailContent.test.ts
@@ -1,4 +1,4 @@
-const { encodeEmailContent, EncodingType } = require('../utils/encodeEmailContent.ts');
+import { encodeEmailContent, EncodingType } from '../utils/encodeEmailContent';
 
 describe('encodeEmailContent', () => {
   test('subject encoding', () => {

--- a/tests/getStateAbbreviation.test.ts
+++ b/tests/getStateAbbreviation.test.ts
@@ -1,4 +1,4 @@
-const { getStateAbbreviation } = require('../utils/getStateAbbreviation.ts');
+import { getStateAbbreviation } from '../utils/getStateAbbreviation';
 
 describe('getStateAbbreviation', () => {
   test('returns abbreviation for known state names', () => {

--- a/tests/getWebsiteScreenshot.test.ts
+++ b/tests/getWebsiteScreenshot.test.ts
@@ -1,0 +1,61 @@
+jest.setTimeout(15000);
+import { getWebsiteScreenshot } from '../functions/screenshot/getWebsiteScreenshot';
+import puppeteer from 'puppeteer-extra';
+import { uploadGDriveHelper } from '../utils/getToken';
+
+jest.mock('puppeteer-extra');
+jest.mock('puppeteer-extra-plugin-stealth', () => jest.fn(() => ({})));
+jest.mock('../utils/getToken');
+
+const mockedPuppeteer = puppeteer as jest.Mocked<typeof puppeteer>;
+const mockedUpload = uploadGDriveHelper as jest.MockedFunction<typeof uploadGDriveHelper>;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockedUpload.mockResolvedValue({
+    data: {
+      files: [
+        {
+          downloadUrl: 'download',
+          webViewLink: 'view',
+          createdTime: 'time',
+          mimeType: 'image/png',
+          iconLink: 'icon',
+        },
+      ],
+    },
+  } as any);
+
+  const page = {
+    setViewport: jest.fn(),
+    setUserAgent: jest.fn(),
+    target: jest.fn().mockReturnValue({ createCDPSession: jest.fn().mockResolvedValue({ send: jest.fn() }) }),
+    goto: jest.fn(),
+    mouse: { move: jest.fn(), click: jest.fn() },
+    screenshot: jest.fn().mockResolvedValue(Buffer.from('img')),
+  } as any;
+
+  const browser = {
+    newPage: jest.fn().mockResolvedValue(page),
+    close: jest.fn(),
+  } as any;
+
+  mockedPuppeteer.launch = jest.fn().mockResolvedValue(browser);
+  mockedPuppeteer.use = jest.fn();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('captures screenshot and uploads', async () => {
+  const promise = getWebsiteScreenshot({ method: 'GET', query: { url: 'https://example.com' } } as any);
+  await jest.runAllTimersAsync();
+  const result = await promise;
+  expect(result).toEqual(
+    expect.objectContaining({
+      status: true,
+      screenshotUrl: expect.objectContaining({ downloadUrl: 'download' }),
+    }),
+  );
+});

--- a/tests/parseQueryParams.test.ts
+++ b/tests/parseQueryParams.test.ts
@@ -1,14 +1,14 @@
-const { parseQueryParams } = require('../utils/parseQueryParams.ts');
+import { parseQueryParams } from '../utils/parseQueryParams';
 
 describe('parseQueryParams', () => {
   test('parses query values into the correct types', () => {
     const result = parseQueryParams({
       page: '10',
       search: 'abc',
-      active: true,
+      active: true as any,
       score: '5.5',
       other: 'text',
-    });
+    } as any);
     expect(result.page).toBe(10);
     expect(result.search).toBe('abc');
     expect(result.active).toBe(true);

--- a/tests/sanitizeFilename.test.ts
+++ b/tests/sanitizeFilename.test.ts
@@ -1,4 +1,4 @@
-const { sanitizeFilename } = require('../utils/sanitizeFilename.ts');
+import { sanitizeFilename } from '../utils/sanitizeFilename';
 
 describe('sanitizeFilename', () => {
   test('removes http or https protocol', () => {

--- a/tests/searchGoogle.test.ts
+++ b/tests/searchGoogle.test.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import { searchGoogle } from '../functions/searchGoogle/googleWebSearch';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('searchGoogle', () => {
+  beforeEach(() => {
+    process.env.SCALE_SERP_API_KEY = 'key';
+    process.env.NODE_ENV = 'test';
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        organic_results: [
+          {
+            title: 'Example',
+            link: 'https://example.com',
+            domain: 'example.com',
+            displayed_link: 'example.com',
+            snippet: 'Result',
+          },
+        ],
+        search_metadata: { pages: [{ engine_url: 'engine', json_url: 'json' }] },
+      },
+    });
+  });
+
+  test('returns search results', async () => {
+    const result = await searchGoogle({ method: 'GET', query: { searchTerm: 'test' } } as any);
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: true,
+        data: expect.objectContaining({ searchUrl: 'engine' }),
+      }),
+    );
+  });
+});
+

--- a/tests/sendTextMessage.test.ts
+++ b/tests/sendTextMessage.test.ts
@@ -1,0 +1,29 @@
+import { sendTextMessage } from '../functions/communication/sendTextMessage';
+import twilio from 'twilio';
+
+jest.mock('twilio');
+
+const mockedTwilio = twilio as jest.MockedFunction<typeof twilio>;
+
+describe('sendTextMessage', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.TWILIO_ACCOUNT_SID = 'sid';
+    process.env.TWILIO_AUTH_TOKEN = 'token';
+    process.env.TWILIO_ASSISTANT_PHONE_NUMBER = '+1234567890';
+
+    mockedTwilio.mockReturnValue({
+      messages: {
+        create: jest.fn().mockResolvedValue({ status: 'sent', sid: '123' }),
+      },
+    } as any);
+  });
+
+  test('sends text message successfully', async () => {
+    const result = await sendTextMessage({ body: { to: '+1', body: 'hi' } } as any);
+    expect(result).toEqual(
+      expect.objectContaining({ success: true, msgId: '123' }),
+    );
+  });
+});
+

--- a/tests/verifyJWT.test.ts
+++ b/tests/verifyJWT.test.ts
@@ -1,5 +1,5 @@
-const jwt = require('jsonwebtoken');
-const { verifyJWT } = require('../utils/verifyJWT.ts');
+import jwt from 'jsonwebtoken';
+import { verifyJWT } from '../utils/verifyJWT';
 
 describe('verifyJWT', () => {
   beforeAll(() => {
@@ -7,7 +7,7 @@ describe('verifyJWT', () => {
   });
 
   test('valid token', () => {
-    const token = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET, {
+    const token = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET as string, {
       algorithm: 'HS256',
       expiresIn: '1h',
     });
@@ -17,7 +17,7 @@ describe('verifyJWT', () => {
   });
 
   test('expired token', () => {
-    const token = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET, {
+    const token = jwt.sign({ foo: 'bar' }, process.env.JWT_SECRET as string, {
       algorithm: 'HS256',
       expiresIn: -10,
     });
@@ -34,3 +34,4 @@ describe('verifyJWT', () => {
     });
   });
 });
+


### PR DESCRIPTION
## Summary
- migrate Jest tests to `.test.ts`
- add ts-jest config for TypeScript tests
- add unit tests that mock network calls for screenshot, Google search and Twilio text message

## Testing
- `NODE_OPTIONS=--max-old-space-size=8192 npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_685336e382e88324b4027fb9bccf6430